### PR TITLE
Downgrade `pointer_interceptor` to version `0.9.1` to avoid crash

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
   debounce_throttle: 2.0.0
 
-  pointer_interceptor: 0.9.3+4
+  pointer_interceptor: 0.9.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Issue

- https://github.com/linagora/tmail-flutter/pull/1701